### PR TITLE
Debug agent query

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ program
     chalk.magenta.bold('A CLI app to parse and query nginx access logs'))
 
 program
-  .command(chalk.blueBright('parse <src> <destination>'))
+  .command('parse <src> <destination>')
   .description('parse access log into JSON and store in specified file')
   .action((source, destination) => {
      const fm = new FileManager(destination, source);

--- a/test/Query-test.js
+++ b/test/Query-test.js
@@ -3,10 +3,10 @@ const expect = chai.expect;
 
 const Query = require('../src/Query');
 const Parser = require('../src/Parser');
-const logData = require('./dummyData.js');
+const logData = require('./dummyLogData.js');
 
 describe('Query', function() {
-
+  console.log(logData.log);
   const happyQuery = new Query(logData.log);
   const sadQuery = new Query(logData.logWithoutTopAgentOrRequest);
 

--- a/test/dummyLogData.js
+++ b/test/dummyLogData.js
@@ -5,7 +5,7 @@ const log = [
     requestMethod: "GET",
     requestPath: "/",
     requestStatus: 200,
-    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9"
+    agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9"
   },
   {
     ipAddress: '10.0.1.4',
@@ -13,7 +13,7 @@ const log = [
     requestMethod: "GET",
     requestPath: "/about",
     requestStatus: 200,
-    userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1"
+    agent: "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1"
   },
   {
     ipAddress: '10.0.1.3',
@@ -21,7 +21,7 @@ const log = [
     requestMethod: "GET",
     requestPath: "/news",
     requestStatus: 200,
-    userAgent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1"
+    agent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1"
   },
   {
     ipAddress: '10.0.1.6',
@@ -29,7 +29,7 @@ const log = [
     requestMethod: "GET",
     requestPath: "/about",
     requestStatus: 200,
-    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9"
+    agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9"
   }
 ];
 
@@ -40,7 +40,7 @@ const logWithoutTopAgentOrRequest = [
     requestMethod: "GET",
     requestPath: "/",
     requestStatus: 200,
-    userAgent: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.3"
+    agent: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.3"
   },
   {
     ipAddress: '10.0.1.4',
@@ -48,7 +48,7 @@ const logWithoutTopAgentOrRequest = [
     requestMethod: "POST",
     requestPath: "/about",
     requestStatus: 200,
-    userAgent: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.3"
+    agent: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.3"
   },
   {
     ipAddress: '10.0.1.3',
@@ -56,7 +56,7 @@ const logWithoutTopAgentOrRequest = [
     requestMethod: "GET",
     requestPath: "/",
     requestStatus: 200,
-    userAgent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1"
+    agent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1"
   },
   {
     ipAddress: '10.0.1.6',
@@ -64,7 +64,7 @@ const logWithoutTopAgentOrRequest = [
     requestMethod: "POST",
     requestPath: "/about",
     requestStatus: 200,
-    userAgent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1"
+    agent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1"
   }
 ];
 


### PR DESCRIPTION
## What
**Fix**
Agent related query tests were failing, this PR fixes them by ensuring alignment between test data and data model

## Why
#22 

**_notes_**
Cause of failure remains somewhat mysterious: test data was correct, but was being registered in Query test as if it hadn't been updated. Solution was to copy test data into new file and reference that file instead.