### PR TITLE
Log order of grok call stack

### DIFF
--- a/src/Grok.js
+++ b/src/Grok.js
@@ -1,18 +1,38 @@
 const grok = require('grok-js');
+// const ngrok = require('node-grok');
 
 class Grok {
   constructor(pattern) {
     this.p = pattern;
   }
 
-  grokString(string) {
-    try {
-      const patterns = grok.loadDefaultSync();
+  async grokString(string) {
+    console.log(1)
+    return await grok.loadDefault(async (err, patterns) => {
+      if (err) {
+        console.error(err);
+        return;
+      }
+
       const pattern = patterns.createPattern(this.p);
-      return pattern.parseSync(string);
-    } catch (err) {
-      console.error(err);
-    }
+
+      return await pattern.parse(string, (err, obj) => {
+        if (err) {
+          console.error(err);
+          return;
+        }
+
+        console.log(2);
+        return obj;
+      });
+    });
+    // try {
+    //   const patterns = grok.loadDefaultSync();
+    //   const pattern = patterns.createPattern(this.p);
+    //   return pattern.parseSync(string);
+    // } catch (err) {
+    //   console.error(err);
+    // }
   }
 }
 

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -6,11 +6,15 @@ class Parser {
     this.pattern = '%{IP:ipAddress} - - \\[%{HTTPDATE:requestTimestamp}\\] "%{WORD:requestMethod} %{URIPATHPARAM:requestPath} HTTP/1.1" %{INT:requestStatus} %{INT:bytes} "%{DATA:mtag}" "%{DATA:agent}"';
   }
 
-  parseLog() {
+  async parseLog() {
     const entries = this.sourceData.split(/\n/).filter(entry => entry !== '');
     const lineParser = new Grok(this.pattern);
-    const transformedData = entries.map(entry => lineParser.grokString(entry))
-      .map(e => {
+    const transformedData = await entries.map((entry, i) => {
+      console.log('mapping', i)
+      lineParser.grokString(entry)
+    });
+    console.log(3, transformedData);
+    const cleanedData = transformedData.map(e => {
         delete e.mtag;
         delete e.bytes;
         return e;


### PR DESCRIPTION
## Debugging in progress

Performance is unacceptably poor with synchronous implementation of the grok-js line parsing functionality: 
**200,000 entry log ==> 5 minutes to parse**
BUT, asynchronous implementation is currently failing (either overwhelms callstack or does not produce outputs in correct order).